### PR TITLE
Correlate two metrics example

### DIFF
--- a/main.clj
+++ b/main.clj
@@ -118,20 +118,28 @@
 		(with {:metric 1 :host nil :state "normal" :service "riemann events/sec"}
 			(rate 15 index)))
 
-
 	(streams
-		(moving-time-window 15
-			(by [:host]
-				(smap (fn [events] (
+		(by [:host]	
+			(moving-time-window 15
+
+				(smap (fn [events]
 					(let [success-service-name "gu_200_ok_request_status_rate-frontend"
 						error-service-name "gu_js_diagnostics_rate-frontend"
-						service-filter (fn [service-name event] (= service-name (:service event)))
+						service-filter (fn [service-name event] (and (:metric event) (= service-name (:service event))))
 						sorted-events (->> events (sort-by :time) reverse)
 						last-success (->> sorted-events (filter (partial service-filter success-service-name)) first)
-						last-error (->> sorted-events (filter (partial service-filter error-service-name)) first)]
+						last-error (->> sorted-events (filter (partial service-filter error-service-name)) first)
+						threshold 0.1]
 						(if (and last-success last-error)
-							(prn (format "Events seen %d; ratio %f"
-								(count events)
-								(double (/ (:metric last-error) (+ (:metric last-success) (:metric last-error)))))))
-					 prn))))))))
+							(let [ratio (double (/ (:metric last-error) (+ (:metric last-success) (:metric last-error))))
+									new-event {:host "riemann" :service "frontend_js_error_ratio" :metric ratio}]
+								(do
+									(info
+										(format "Events seen %d; ratio %f; status %s"
+											(count events)
+											ratio
+											(if (> ratio threshold) "bad" "okay")))
+									(if (> ratio threshold)
+										(call-rescue new-event (list critical))
+										(call-rescue new-event (list normal)))))))))))))
 


### PR DESCRIPTION
This stream prints a ratio for two named metrics in a stream. The goal is to just illustrate the technique rather than create a working rule.
