### PR TITLE
Create my first alert

### DIFF
--- a/main.clj
+++ b/main.clj
@@ -313,6 +313,9 @@
 			r2frontend-http-cluster-response-time
 			r2frontend-db-response-time
 			discussionapi-http-response-time
+			content-api-host-item-request-time
+			content-api-host-search-request-time
+			content-api-request-time
 			content-api-request-rate)))
 
 	; TODO - check this - the alerta check seems non-sensical as it uses a static value	


### PR DESCRIPTION
I suspect that adding 

```
(match :grid "ContentApi" metric)
```

To the metrics will make them turn up in Alerta under ContentAPI instead of under Other Services, but didn't want to mess with that.  Instead I want to see my first alert actually turn up, so I'll follow up with more PR's once this is merged and I can see it
