### PR TITLE
Adding port 8080 to the endpoints

### DIFF
--- a/alerta.clj
+++ b/alerta.clj
@@ -4,8 +4,8 @@
 (def version "1.0.0")
 
 (def alerta-endpoints
-	{:alert "http://monitoring/alerta/api/v2/alerts/alert.json"
-	:heartbeat "http://monitoring/alerta/api/v2/heartbeats/heartbeat.json"})
+	{:alert "http://monitoring:8080/alerta/api/v2/alerts/alert.json"
+	:heartbeat "http://monitoring:8080/alerta/api/v2/heartbeats/heartbeat.json"})
 
 (defn post-to-alerta
   "POST to the Alerta REST API."


### PR DESCRIPTION
In the new infmonalr servers alerta API is listening on port 8080.
